### PR TITLE
Error token support

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -351,7 +351,7 @@ impl<I: Io> TdsTransport<I> {
             // read the associated length for a token, if available
             if let ReadState::Generic(token, None) = self.read_state {
                 self.read_state = match token {
-                    Tokens::SSPI | Tokens::EnvChange | Tokens::Info | Tokens::LoginAck => {
+                    Tokens::SSPI | Tokens::EnvChange | Tokens::Info | Tokens::Error | Tokens::LoginAck => {
                         ReadState::Generic(token, Some(try!(self.inner.read_u16::<LittleEndian>()) as usize))
                     },
                     Tokens::Row => {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -249,6 +249,7 @@ impl<'a> ColumnData<'a> {
             TypeInfo::FixedLen(ref fixed_ty) => {
                 match *fixed_ty {
                     FixedLenType::Int4 => ColumnData::I32(try!(trans.inner.read_i32::<LittleEndian>())),
+                    FixedLenType::Int8 => ColumnData::I64(try!(trans.inner.read_i64::<LittleEndian>())),
                     _ => panic!("unsupported fixed type decoding: {:?}", fixed_ty)
                 }
             },


### PR DESCRIPTION
I tried to implement what I believe the correct handling for Error tokens (§2.2.7.9 of MS-TDS spec) is.

However, this code seems to only work if I discard a `u16` worth of data prior to parsing the Error token. This might correspond to the `Length` field in the spec, but I was under the impression that this is already taken into account elsewhere. Moreover, `TokenError`'s definition is almost identical to `TokenInfo`'s (cf. §2.2.7.11), but the implementation for `TokenInfo` does not discard a `u16`'s worth of data.

This code works reliably for me, though, and is much nicer than the `unrecognized token 0xaa` message that came back before!