### PR TITLE
Fix compile errors with recent Rust nightly & on OS X

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,7 +528,8 @@ impl<'a> ToIo<TcpStream> for &'a SocketAddr {
     }
 }
 
-enum DynamicConnectionTarget {
+#[doc(hidden)]
+pub enum DynamicConnectionTarget {
     Tcp(SocketAddr),
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -239,7 +239,7 @@ pub mod tls {
         let disable_verification = host.is_none();
         let mut builder = TlsConnector::builder().unwrap();
 
-        let panic;
+        let mut panic = true;
         #[cfg(windows)]
         {
             panic = false;


### PR DESCRIPTION
Recent Rust nightlies (>= 2017-07-17 for sure, possibly prior) trip up on the fact that `DynamicConnectionTarget` isn't public; b7b8862 fixes this.

Also, compilation on OS X panics because `panic` is uninitialized on `src/transport.rs:264` because neither of the conditional compilation blocks apply. The fix be243a8 fixes compilation (so that dependent crates work on OS X), though I suspect tiberius will still fail to work on OS X even with the fix.
