### PR TITLE
make ToSql publicly accessible 

### DIFF
--- a/tiberius/src/types/mod.rs
+++ b/tiberius/src/types/mod.rs
@@ -57,6 +57,7 @@ mod time;
 pub mod prelude {
     pub use super::Guid;
     pub use super::time::{Date, DateTime, DateTime2, SmallDateTime, Time};
+    pub use super::ToSql;
 }
 
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
so you can use function parameters like `sql_params : &'a[&'a tiberius::ty::ToSql]` in your own code