### PR TITLE
Use TCP_NODELAY to avoid latency spikes

### DIFF
--- a/tiberius/src/lib.rs
+++ b/tiberius/src/lib.rs
@@ -586,6 +586,10 @@ impl ConnectTarget {
         match self {
             ConnectTarget::Tcp(ref addr) => {
                 let future = TcpStream::connect(addr, handle)
+                    .and_then(|stream| {
+                        stream.set_nodelay(true)?;
+                        Ok(stream)
+                    })
                     .from_err::<TdsError>()
                     .map(|stream| Box::new(stream) as Box<BoxableIo>);
                 Box::new(future)


### PR DESCRIPTION
When a command (or part of a command) is much smaller than the network MTU, a (well-known) problem occurs between delayed ACKs and Nagle's algorithm. Specifically, Nagle tries to maximize packet size, and will avoid sending a non-full packet unless there are no currently unacked packets. Delayed ACKs delays sending ACKs to (again) minimize the number of packets sent over the network, and instead coalesce many ACKs over a prolonged period of time. When sending small messages, these interact poorly: Nagle will effectively not let you send a packet until the delayed ACK timeout expires on the other host.

The standard dictates that the delayed ACK timeout is at most 500ms, but in Linux, the actual delays are dictated by [`TCP_DELACK_MIN/MAX`](https://elixir.bootlin.com/linux/latest/ident/TCP_DELACK_MIN), and the minimum is usually set to 40ms. These 40ms will appear as an artificial delay to some commands, without the server or client doing any useful work.

Fixes #42.