### PR TITLE
Some types casting

### DIFF
--- a/tiberius/src/tokens.rs
+++ b/tiberius/src/tokens.rs
@@ -457,6 +457,7 @@ impl<I: Io> ParseToken<I> for TokenNbcRow {
             // calculate size of the null-bitmap and read it
             let bitmap_size = (col_meta.columns.len() + 8 - 1) / 8;
             trans.inner.row_bitmap = trans.inner.read_bytes(bitmap_size);
+            trans.inner.commit_rd_buffer();
         }
 
         if trans.inner.row_bitmap.is_some() {

--- a/tiberius/src/types/mod.rs
+++ b/tiberius/src/types/mod.rs
@@ -643,7 +643,8 @@ impl<'a, S: FromColumnData<'a> + 'a> FromColumnData<'a> for Option<S> {
 
 from_column_data!(
     // integers are auto-castable on receiving
-    bool:       ColumnData::Bit(val) => val;
+    bool:       ColumnData::Bit(val) => val,
+                ColumnData::I8(val) => val != 0;
     i8:         ColumnData::I8(val) => val;
     i16:        ColumnData::I16(val) => val;
     i32:        ColumnData::I32(val) => val;

--- a/tiberius/src/types/mod.rs
+++ b/tiberius/src/types/mod.rs
@@ -647,7 +647,9 @@ from_column_data!(
                 ColumnData::I8(val) => val != 0;
     i8:         ColumnData::I8(val) => val;
     i16:        ColumnData::I16(val) => val;
-    i32:        ColumnData::I32(val) => val;
+    i32:        ColumnData::I32(val) => val,
+                ColumnData::I16(val) => val as i32,
+                ColumnData::I8(val) => val as i32;
     i64:        ColumnData::I64(val) => val;
     f32:        ColumnData::F32(val) => val;
     f64:        ColumnData::F64(val) => val;

--- a/tiberius/src/types/time.rs
+++ b/tiberius/src/types/time.rs
@@ -222,7 +222,11 @@ mod chrono {
                 from_days(dt.0.days() as i64, 1),
                 NaiveTime::from_hms(0,0,0) + Duration::nanoseconds(dt.1.increments as i64 * 10i64.pow(9 - dt.1.scale as u32))
             );
-        NaiveDate:      ColumnData::Date(ref date) => from_days(date.days() as i64, 1)
+        NaiveDate:      
+            ColumnData::Date(ref date) => from_days(date.days() as i64, 1),
+            ColumnData::SmallDateTime(ref dt) => from_days(dt.days as i64, 1900),
+            ColumnData::DateTime(ref dt) => from_days(dt.days as i64, 1900),
+            ColumnData::DateTime2(ref dt) => from_days(dt.0.days() as i64, 1)
     );
     to_column_data!(self_,
         NaiveDateTime => {


### PR DESCRIPTION
In real life in legacy databases there are different type of fields used for storing bolean/integers/date values. In my case, I have "bit" and "tinyint" fields with boolean values; "date" and "datetime" fields with just Date values... I can use try_get() method to guess what the actual type inside, but I don't like do so. I like to have automatic casting where it is logically right.