### PR TITLE
trivial: make `FromColumnData` public

### DIFF
--- a/tiberius/src/types/mod.rs
+++ b/tiberius/src/types/mod.rs
@@ -66,7 +66,7 @@ pub mod prelude {
     pub use super::Guid;
     pub use super::numeric::Numeric;
     pub use super::time::{Date, DateTime, DateTime2, SmallDateTime, Time};
-    pub use super::ToSql;
+    pub use super::{ToSql, FromColumnData};
 }
 
 uint_enum! {


### PR DESCRIPTION
This makes `FromColumnData` trait accessible to the caller so that wrappers around `get()` and `try_get()` can be written.

Signed-off-by: Alexey Galakhov <agalakhov@snapview.de>