### PR TITLE
trivial: make `StmtStream` `Send`

### DIFF
--- a/tiberius/src/stmt.rs
+++ b/tiberius/src/stmt.rs
@@ -70,7 +70,7 @@ pub struct StmtStream<I: BoxableIo, R: StmtResult<I>> {
     /// This marker simply is used to allow this struct to be generic over a possible
     /// result, which allows us to share all state logic within this struct
     /// (e.g. we don't need a query specific future)
-    _marker: PhantomData<*const R>,
+    _marker: PhantomData<R>,
 }
 
 impl<I: BoxableIo, R: StmtResult<I>> StmtStream<I, R> {


### PR DESCRIPTION
`StmtStream` was not `Send` due to pointer in `PhantomData`. This pointer makes no sense since `PhantomData` is already zero-sized.

This is likely to fix #103.

Signed-off-by: Alexey Galakhov <agalakhov@snapview.de>